### PR TITLE
add coalesce in select to fix a db error during setup

### DIFF
--- a/htdocs/setup.php
+++ b/htdocs/setup.php
@@ -954,7 +954,7 @@ if ($do=='editview2') {
 				insert into blackboxviews set
 				template= ':template',
 				viewname= ':viewname',
-				position= (select max(v.position)+1 from blackboxviews v)
+				position= (select coalesce(max(v.position),0)+1 from blackboxviews v)
 			";	
 			$params= array('template'=>$viewtemplate,'viewname'=>$viewname);
 			$db->query($query,$params) or codeerror('DB error',__FILE__,__LINE__);


### PR DESCRIPTION
Bug report and patch originally submitted to google code at:
https://code.google.com/p/theblackboxproject/issues/detail?id=5

---

What steps will reproduce the problem?
1. Install system to new database.
2. Create tables.
3. Try to add a view.

The setup page reported an error.  I saw it was occurring during a SQL query.  I debugged, and discovered the query was:

insert into blackboxviews set template= 'template-view2.html' , viewname= 'view2', position= (select max(v.position)+1 from blackboxviews v)

Running this query manually, mysql reports:

ERROR 1048 (23000): Column 'position' cannot be null

I fixed the query by adding coalesce() like so:

insert into blackboxviews set template= 'template-view2.html' , viewname= 'view2', position= (select coalesce(max(v.position),0)+1 from blackboxviews v)

I'm attaching a one-line patch that implements this fix.
