### PR TITLE
prevent output that can interfere with usage as a webservice

### DIFF
--- a/htdocs/real.php
+++ b/htdocs/real.php
@@ -24,7 +24,10 @@ $blackbox= new Blackbox();
 $modules= $blackbox->modules;
 	
 foreach ($modules as $mod=>$module) {
+        // prevent output that can interfere with usage as a webservice
+	ob_start();
 	$module->read_direct();
+	ob_end_clean();
 	$profiler->add("Module $module->name read direct");
 }		
 


### PR DESCRIPTION
This is just a quick/dirty patch I made because there was warning output from somewhere deeper that was interfering with the output of real.php and making it harder to parse for client.

Here is the clean output with the patch:

```
Classic Unit|150|&nbsp;
Firmware Date|2014-12-18|&nbsp;
Lifetime kWh|3601.5|kWh
Uptime|0.42|days
FET Temp|46.5|&deg;C
Efficiency|99|%
Output Power|2712|W
Output Voltage|54.7|V
Output Current|49.5|A
Charge Stage|Bulk|&nbsp;
Battery Temp|23|&deg;C
State of Charge|100|%
Days Since Float|1|days
Max Batt Voltage|54.7|V
Min Battery Voltage|54.7|V
PV Voltage|59.1|V
PV Current|45.5|A
```

Here is the dirty output before the patch:

```
warning: value 4387 not found in registers. skipping.
warning: value 4386 not found in registers. skipping.
Classic Unit|150|&nbsp;
Firmware Date|2014-12-18|&nbsp;
Lifetime kWh|3601.5|kWh
Uptime|0.42|days
FET Temp|46.5|&deg;C
Efficiency|99|%
Output Power|2712|W
Output Voltage|54.7|V
Output Current|49.5|A
Charge Stage|Bulk|&nbsp;
Battery Temp|23|&deg;C
State of Charge|100|%
Days Since Float|1|days
Max Batt Voltage|54.7|V
Min Battery Voltage|54.7|V
PV Voltage|59.1|V
PV Current|45.5|A
```

Clearly the warnings should eventually be resolved but this patch was a much faster path to getting clean/usable output.
