### PR TITLE
improvements to real.php.

### DIFF
--- a/htdocs/real.php
+++ b/htdocs/real.php
@@ -1,5 +1,36 @@
 <?php
 
+// return cached file if within last 30 secs.
+$cache_file = '/tmp/real.php.cache';
+if( @$_GET['cached'] != 'no' ) {
+    if( time() - @filemtime($cache_file) < 30 ) {
+        $fh = fopen( $cache_file, 'r' );
+        if( flock( $fh, LOCK_SH ) ) {
+            $buf = stream_get_contents( $fh );
+            echo $buf;
+            exit;
+        }
+    }
+}
+
+// We open and lock the cache file first in order to
+// serialize queries and ensure that the charger controller
+// is only queried once per cache-period regardless of how many
+// http requests we receive.
+//
+// we use 'a' instead of 'w' to avoid truncating file before lock is obtained.
+$fh = fopen( $cache_file, 'a');
+if( !$fh ) {
+    die( "Could not open cache file\n" );
+}
+
+if( !flock( $fh, LOCK_EX )) {
+   die( "Could not lock cache file\n" );
+}
+ftruncate($fh, 0);
+
+
+
 
 /** 
  * Wireframe for realtime calls via ajax
@@ -24,9 +55,13 @@ $blackbox= new Blackbox();
 $modules= $blackbox->modules;
 	
 foreach ($modules as $mod=>$module) {
+        // prevent output that can interfere with usage as a webservice
+	ob_start();
 	$module->read_direct();
+	ob_end_clean();
 	$profiler->add("Module $module->name read direct");
 }		
+
 
 
 //get elements
@@ -37,6 +72,8 @@ $query= "
 ";	
 $params= array('id_view'=>$id_view);
 $result= $db->query($query,$params) or codeerror('DB error',__FILE__,__LINE__);
+
+$buf = '';
 while ($row= $db->fetch_row($result)) {
 	$id_element=   $row['id_element'];
 	$name=         $row['name'];
@@ -60,11 +97,18 @@ while ($row= $db->fetch_row($result)) {
 
 			if (preg_match("/^\d+$/",$resolution) and preg_match("/^[\d.]+$/",$value)) $value= number_format($value, (int)$resolution, '.','');
 
-			print"$name|$value|$unit\n"; //json todo
+			$buf .= "$name|$value|$unit\n"; //json todo
 		}
 	}
 	
 }
+
+fwrite( $fh, $buf );
+flock( $fh, LOCK_UN );
+fclose( $fh );
+
+echo $buf;
+
 
 #print $profiler->dump();
 

--- a/htdocs/real.php
+++ b/htdocs/real.php
@@ -24,7 +24,10 @@ $blackbox= new Blackbox();
 $modules= $blackbox->modules;
 	
 foreach ($modules as $mod=>$module) {
+        // prevent output that can interfere with usage as a webservice
+	ob_start();
 	$module->read_direct();
+	ob_end_clean();
 	$profiler->add("Module $module->name read direct");
 }		
 

--- a/htdocs/setup.php
+++ b/htdocs/setup.php
@@ -954,7 +954,7 @@ if ($do=='editview2') {
 				insert into blackboxviews set
 				template= ':template',
 				viewname= ':viewname',
-				position= (select max(v.position)+1 from blackboxviews v)
+				position= (select coalesce(max(v.position),0)+1 from blackboxviews v)
 			";	
 			$params= array('template'=>$viewtemplate,'viewname'=>$viewname);
 			$db->query($query,$params) or codeerror('DB error',__FILE__,__LINE__);


### PR DESCRIPTION
1. serialize charge controller queries via lockfile.
2. cache results for 30 seconds in a file.
3. prevent output that can interfere with usage as a webservice